### PR TITLE
Newer rvm files

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+volatile_hash

--- a/.ruby-version
+++ b/.ruby-version
@@ -1,0 +1,1 @@
+default

--- a/.rvmrc
+++ b/.rvmrc
@@ -1,2 +1,0 @@
-rvm use ruby-1.9.2-p180@volatile_hash --create
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    volatile_hash (0.0.1)
+    volatile_hash (0.0.2)
 
 GEM
   remote: http://rubygems.org/


### PR DESCRIPTION
Use newer RVM files `.ruby-version` and `.ruby-gemset`, and allow using system default ruby (works fine with Ruby 2.0)
